### PR TITLE
Start to try and simplify configuration to make it less verbose

### DIFF
--- a/readme.org
+++ b/readme.org
@@ -22,6 +22,7 @@ Lebar is bundled with a default configuration but it can be overridden with a cu
 
 (local blocks (require "blocks.fnl"))
 (local themes (require "themes.fnl"))
+(local lib (require "lib.fnl"))
 
 (set config.refresh-seconds 0.001)
 
@@ -45,113 +46,69 @@ Lebar is bundled with a default configuration but it can be overridden with a cu
 (set config.background-color config.theme.black)
 (set config.foreground-color config.theme.text)
 
-; default configuration for blocks
 (set config.block {})
-(set config.block.defaults {})
-(set config.block.defaults.margin 3)
-(set config.block.defaults.padding-x 3)
-(set config.block.defaults.width 140)
-(set config.block.defaults.height 20)
-(set config.block.defaults.auto-fit true)
-(set config.block.defaults.label "")
-(set config.block.defaults.font "JetBrainsMonoNerdFont-Regular.ttf")
-(set config.block.defaults.font-size 14)
-(set config.block.defaults.radius 6)
-(set config.block.defaults.love-font (love.graphics.newFont config.block.defaults.font config.block.defaults.font-size))
-(set config.block.defaults.background-color config.theme.black)
-(set config.block.defaults.foreground-color config.theme.text)
 
 ; configuration for the separator block
-(set config.block.separator {})
-(set config.block.separator.margin config.block.defaults.margin)
+(set config.block.separator (lib.default-settings config.theme))
 (set config.block.separator.padding-x 2)
-(set config.block.separator.radius config.block.defaults.radius)
-(set config.block.separator.width config.block.defaults.width)
-(set config.block.separator.height config.block.defaults.height)
-(set config.block.separator.font config.block.defaults.font)
-(set config.block.separator.font-size config.block.defaults.font-size)
-(set config.block.separator.love-font (love.graphics.newFont config.block.separator.font config.block.separator.font-size))
 (set config.block.separator.text "|")
-(set config.block.separator.foreground-color config.theme.gray-2)
-(set config.block.separator.background-color config.theme.black)
-(set config.block.separator.auto-fit config.block.defaults.auto-fit)
+(set config.block.separator.foreground-color config.theme.gray-3)
 
 ; configuration for the time block
-(set config.block.time {})
-(set config.block.time.margin config.block.defaults.margin)
-(set config.block.time.padding-x config.block.defaults.padding-x)
-(set config.block.time.width config.block.defaults.width)
-(set config.block.time.height config.block.defaults.height)
-(set config.block.time.radius config.block.defaults.radius)
+(set config.block.time (lib.default-settings config.theme))
 (set config.block.time.format "%%a %%d, %%H:%%M")
-(set config.block.time.label config.block.defaults.label)
-(set config.block.time.font config.block.defaults.font)
-(set config.block.time.font-size config.block.defaults.font-size)
-(set config.block.time.love-font (love.graphics.newFont config.block.time.font config.block.time.font-size))
-(set config.block.time.foreground-color config.theme.text)
-(set config.block.time.background-color config.theme.black)
-(set config.block.time.auto-fit config.block.defaults.auto-fit)
+
+; configuration for the power block
+(set config.block.power (lib.default-settings config.theme))
+(set config.block.power.include-remaining-time true)
+
+; configuration for the shell block
+(set config.block.shell (lib.default-settings config.theme))
+
+; configuration for the memory block
+(set config.block.memory (lib.default-settings config.theme))
+(set config.block.memory.label " MEM ")
+
+; configuration for the dunst block
+(set config.block.dunst (lib.default-settings config.theme))
+(set config.block.dunst.label " ")
 
 ; configuration for the user block
-(set config.block.user {})
-(set config.block.user.width config.block.defaults.width)
-(set config.block.user.height config.block.defaults.height)
-(set config.block.user.margin config.block.defaults.margin)
-(set config.block.user.padding-x config.block.defaults.padding-x)
-(set config.block.user.radius config.block.defaults.radius)
+(set config.block.user (lib.default-settings config.theme))
 (set config.block.user.label " ")
-(set config.block.user.font config.block.defaults.font)
-(set config.block.user.font-size config.block.defaults.font-size)
-(set config.block.user.love-font (love.graphics.newFont config.block.user.font config.block.user.font-size))
-(set config.block.user.foreground-color config.theme.text)
-(set config.block.user.background-color config.theme.gray-2)
-(set config.block.user.auto-fit config.block.defaults.auto-fit)
+(set config.block.user.background-color config.theme.blue)
+(set config.block.user.foreground-color config.theme.black)
 
 ; configuration for the cpu block
-(set config.block.cpu {})
-(set config.block.cpu.width config.block.defaults.width)
-(set config.block.cpu.height config.block.defaults.height)
-(set config.block.cpu.margin config.block.defaults.margin)
-(set config.block.cpu.padding-x config.block.defaults.padding-x)
-(set config.block.cpu.radius config.block.defaults.radius)
+(set config.block.cpu (lib.default-settings config.theme))
 (set config.block.cpu.label " CPU ")
-(set config.block.cpu.font config.block.defaults.font)
-(set config.block.cpu.font-size config.block.defaults.font-size)
-(set config.block.cpu.love-font (love.graphics.newFont config.block.cpu.font config.block.cpu.font-size))
-(set config.block.cpu.foreground-color config.block.defaults.foreground-color)
-(set config.block.cpu.background-color config.block.defaults.background-color)
-(set config.block.cpu.auto-fit config.block.defaults.auto-fit)
 (set config.block.cpu.ok-threshold 50)
 
 ; configuration for the window-title block
-(set config.block.window-title {})
-(set config.block.window-title.width config.block.defaults.width)
-(set config.block.window-title.height config.block.defaults.height)
-(set config.block.window-title.margin config.block.defaults.margin)
-(set config.block.window-title.padding-x config.block.defaults.padding-x)
-(set config.block.window-title.radius config.block.defaults.radius)
+(set config.block.window-title (lib.default-settings config.theme))
+(set config.block.window-title.love-font (love.graphics.newFont "JetBrainsMonoNerdFont-Italic.ttf" 14))
 (set config.block.window-title.label " ")
-(set config.block.window-title.font "JetBrainsMonoNerdFont-Italic.ttf")
-(set config.block.window-title.font-size config.block.defaults.font-size)
-(set config.block.window-title.love-font (love.graphics.newFont config.block.window-title.font config.block.window-title.font-size))
 (set config.block.window-title.foreground-color config.theme.gray-2)
-(set config.block.window-title.background-color config.theme.black)
-(set config.block.window-title.auto-fit config.block.defaults.auto-fit)
+
+; configuration for the i3-workspace block
+(set config.block.i3-workspace (lib.default-settings config.theme))
+
+; configuration for the free-disk-space block
+(set config.block.free-disk-space (lib.default-settings config.theme))
+(set config.block.free-disk-space.label " ")
+
+; configuration for the pacman block
+(set config.block.pacman (lib.default-settings config.theme))
+(set config.block.pacman.label "  ")
+
+; configuration for the i3-binding-state block
+(set config.block.i3-binding-state (lib.default-settings config.theme))
+(set config.block.i3-binding-state.label " ")
 
 ; configuration for the wmctrl block
-(set config.block.wmctrl {})
-(set config.block.wmctrl.width config.block.defaults.width)
-(set config.block.wmctrl.height config.block.defaults.height)
-(set config.block.wmctrl.margin (+ config.block.defaults.margin 1))
-(set config.block.wmctrl.padding-x config.block.defaults.padding-x)
+(set config.block.wmctrl (lib.default-settings config.theme))
+(set config.block.wmctrl.margin (+ config.block.wmctrl.margin 1))
 (set config.block.wmctrl.radius 4)
-(set config.block.wmctrl.label config.block.defaults.label)
-(set config.block.wmctrl.font config.block.defaults.font)
-(set config.block.wmctrl.font-size config.block.defaults.font-size)
-(set config.block.wmctrl.love-font (love.graphics.newFont config.block.wmctrl.font config.block.wmctrl.font-size))
-(set config.block.wmctrl.foreground-color config.theme.black)
-(set config.block.wmctrl.background-color config.theme.green)
-(set config.block.wmctrl.auto-fit config.block.defaults.auto-fit)
 
 (set config.all-blocks 
      {:left 
@@ -162,8 +119,11 @@ Lebar is bundled with a default configuration but it can be overridden with a cu
       :right 
       [blocks.time 
        blocks.separator
-       blocks.cpu
-       blocks.separator]})
+       blocks.power
+       blocks.separator
+       blocks.memory
+       blocks.separator
+       blocks.cpu]})
 
 (set config.minimal-blocks 
      {:left 
@@ -172,8 +132,6 @@ Lebar is bundled with a default configuration but it can be overridden with a cu
       :right 
       [blocks.time 
        blocks.separator]})
-
-config
 
 #+end_src
 

--- a/src/config.fnl
+++ b/src/config.fnl
@@ -2,6 +2,7 @@
 
 (local blocks (require "blocks.fnl"))
 (local themes (require "themes.fnl"))
+(local lib (require "lib.fnl"))
 
 (set config.refresh-seconds 0.001)
 
@@ -25,250 +26,75 @@
 (set config.background-color config.theme.black)
 (set config.foreground-color config.theme.text)
 
-; default configuration for blocks
 (set config.block {})
-(set config.block.defaults {})
-(set config.block.defaults.margin 3)
-(set config.block.defaults.padding-x 3)
-(set config.block.defaults.width 140)
-(set config.block.defaults.height 20)
-(set config.block.defaults.auto-fit true)
-(set config.block.defaults.label "")
-(set config.block.defaults.font "JetBrainsMonoNerdFont-Regular.ttf")
-(set config.block.defaults.font-size 14)
-(set config.block.defaults.radius 6)
-(set config.block.defaults.love-font (love.graphics.newFont config.block.defaults.font config.block.defaults.font-size))
-(set config.block.defaults.background-color config.theme.black)
-(set config.block.defaults.foreground-color config.theme.text)
 
 ; configuration for the separator block
-(set config.block.separator {})
-(set config.block.separator.margin config.block.defaults.margin)
+(set config.block.separator (lib.default-settings config.theme))
 (set config.block.separator.padding-x 2)
-(set config.block.separator.radius config.block.defaults.radius)
-(set config.block.separator.width config.block.defaults.width)
-(set config.block.separator.height config.block.defaults.height)
-(set config.block.separator.font config.block.defaults.font)
-(set config.block.separator.font-size config.block.defaults.font-size)
-(set config.block.separator.love-font (love.graphics.newFont config.block.separator.font config.block.separator.font-size))
 (set config.block.separator.text "|")
-(set config.block.separator.foreground-color config.theme.gray-2)
-(set config.block.separator.background-color config.theme.black)
-(set config.block.separator.auto-fit config.block.defaults.auto-fit)
+(set config.block.separator.foreground-color config.theme.gray-3)
 
 ; configuration for the time block
-(set config.block.time {})
-(set config.block.time.margin config.block.defaults.margin)
-(set config.block.time.padding-x config.block.defaults.padding-x)
-(set config.block.time.width config.block.defaults.width)
-(set config.block.time.height config.block.defaults.height)
-(set config.block.time.radius config.block.defaults.radius)
+(set config.block.time (lib.default-settings config.theme))
 (set config.block.time.format "%%a %%d, %%H:%%M")
-(set config.block.time.label config.block.defaults.label)
-(set config.block.time.font config.block.defaults.font)
-(set config.block.time.font-size config.block.defaults.font-size)
-(set config.block.time.love-font (love.graphics.newFont config.block.time.font config.block.time.font-size))
-(set config.block.time.foreground-color config.theme.text)
-(set config.block.time.background-color config.theme.black)
-(set config.block.time.auto-fit config.block.defaults.auto-fit)
 
 ; configuration for the power block
-(set config.block.power {})
-(set config.block.power.width config.block.defaults.width)
-(set config.block.power.height config.block.defaults.height)
-(set config.block.power.margin config.block.defaults.margin)
-(set config.block.power.padding-x config.block.defaults.padding-x)
-(set config.block.power.radius config.block.defaults.radius)
-(set config.block.power.label config.block.defaults.label)
-(set config.block.power.font config.block.defaults.font)
-(set config.block.power.font-size config.block.defaults.font-size)
-(set config.block.power.love-font (love.graphics.newFont config.block.power.font config.block.power.font-size))
-(set config.block.power.foreground-color config.theme.text)
-(set config.block.power.background-color config.theme.black)
-(set config.block.power.auto-fit config.block.defaults.auto-fit)
+(set config.block.power (lib.default-settings config.theme))
 (set config.block.power.include-remaining-time true)
 
 ; configuration for the shell block
-(set config.block.shell {})
-(set config.block.shell.width config.block.defaults.width)
-(set config.block.shell.height config.block.defaults.height)
-(set config.block.shell.margin config.block.defaults.margin)
-(set config.block.shell.padding-x config.block.defaults.padding-x)
-(set config.block.shell.label config.block.defaults.label)
-(set config.block.shell.radius config.block.defaults.radius)
-(set config.block.shell.font config.block.defaults.font)
-(set config.block.shell.font-size config.block.defaults.font-size)
-(set config.block.shell.love-font (love.graphics.newFont config.block.shell.font config.block.shell.font-size))
-(set config.block.shell.foreground-color config.block.defaults.foreground-color)
-(set config.block.shell.background-color config.block.defaults.background-color)
-(set config.block.shell.auto-fit config.block.defaults.auto-fit)
+(set config.block.shell (lib.default-settings config.theme))
 
 ; configuration for the memory block
-(set config.block.memory {})
-(set config.block.memory.width config.block.defaults.width)
-(set config.block.memory.height config.block.defaults.height)
-(set config.block.memory.margin config.block.defaults.margin)
-(set config.block.memory.padding-x config.block.defaults.padding-x)
-(set config.block.memory.radius config.block.defaults.radius)
+(set config.block.memory (lib.default-settings config.theme))
 (set config.block.memory.label " MEM ")
-(set config.block.memory.font config.block.defaults.font)
-(set config.block.memory.font-size config.block.defaults.font-size)
-(set config.block.memory.love-font (love.graphics.newFont config.block.memory.font config.block.memory.font-size))
-(set config.block.memory.foreground-color config.theme.text)
-(set config.block.memory.background-color config.theme.black)
-(set config.block.memory.auto-fit config.block.defaults.auto-fit)
 
 ; configuration for the dunst block
-(set config.block.dunst {})
-(set config.block.dunst.width config.block.defaults.width)
-(set config.block.dunst.height config.block.defaults.height)
-(set config.block.dunst.margin config.block.defaults.margin)
-(set config.block.dunst.padding-x config.block.defaults.padding-x)
-(set config.block.dunst.radius config.block.defaults.radius)
+(set config.block.dunst (lib.default-settings config.theme))
 (set config.block.dunst.label " ")
-(set config.block.dunst.font config.block.defaults.font)
-(set config.block.dunst.font-size config.block.defaults.font-size)
-(set config.block.dunst.love-font (love.graphics.newFont config.block.dunst.font config.block.dunst.font-size))
-(set config.block.dunst.foreground-color config.theme.red)
-(set config.block.dunst.background-color config.theme.black)
-(set config.block.dunst.auto-fit config.block.defaults.auto-fit)
 
 ; configuration for the user block
-(set config.block.user {})
-(set config.block.user.width config.block.defaults.width)
-(set config.block.user.height config.block.defaults.height)
-(set config.block.user.margin config.block.defaults.margin)
-(set config.block.user.padding-x config.block.defaults.padding-x)
-(set config.block.user.radius config.block.defaults.radius)
+(set config.block.user (lib.default-settings config.theme))
 (set config.block.user.label " ")
-(set config.block.user.font config.block.defaults.font)
-(set config.block.user.font-size config.block.defaults.font-size)
-(set config.block.user.love-font (love.graphics.newFont config.block.user.font config.block.user.font-size))
-(set config.block.user.foreground-color config.theme.text)
-(set config.block.user.background-color config.theme.gray-2)
-(set config.block.user.auto-fit config.block.defaults.auto-fit)
+(set config.block.user.background-color config.theme.blue)
+(set config.block.user.foreground-color config.theme.black)
 
 ; configuration for the cpu block
-(set config.block.cpu {})
-(set config.block.cpu.width config.block.defaults.width)
-(set config.block.cpu.height config.block.defaults.height)
-(set config.block.cpu.margin config.block.defaults.margin)
-(set config.block.cpu.padding-x config.block.defaults.padding-x)
-(set config.block.cpu.radius config.block.defaults.radius)
+(set config.block.cpu (lib.default-settings config.theme))
 (set config.block.cpu.label " CPU ")
-(set config.block.cpu.font config.block.defaults.font)
-(set config.block.cpu.font-size config.block.defaults.font-size)
-(set config.block.cpu.love-font (love.graphics.newFont config.block.cpu.font config.block.cpu.font-size))
-(set config.block.cpu.foreground-color config.block.defaults.foreground-color)
-(set config.block.cpu.background-color config.block.defaults.background-color)
-(set config.block.cpu.auto-fit config.block.defaults.auto-fit)
 (set config.block.cpu.ok-threshold 50)
 
 ; configuration for the window-title block
-(set config.block.window-title {})
-(set config.block.window-title.width config.block.defaults.width)
-(set config.block.window-title.height config.block.defaults.height)
-(set config.block.window-title.margin config.block.defaults.margin)
-(set config.block.window-title.padding-x config.block.defaults.padding-x)
-(set config.block.window-title.radius config.block.defaults.radius)
+(set config.block.window-title (lib.default-settings config.theme))
+(set config.block.window-title.love-font (love.graphics.newFont "JetBrainsMonoNerdFont-Italic.ttf" 14))
 (set config.block.window-title.label " ")
-(set config.block.window-title.font "JetBrainsMonoNerdFont-Italic.ttf")
-(set config.block.window-title.font-size config.block.defaults.font-size)
-(set config.block.window-title.love-font (love.graphics.newFont config.block.window-title.font config.block.window-title.font-size))
 (set config.block.window-title.foreground-color config.theme.gray-2)
-(set config.block.window-title.background-color config.theme.black)
-(set config.block.window-title.auto-fit config.block.defaults.auto-fit)
 
 ; configuration for the i3-workspace block
-(set config.block.i3-workspace {})
-(set config.block.i3-workspace.width config.block.defaults.width)
-(set config.block.i3-workspace.height config.block.defaults.height)
-(set config.block.i3-workspace.margin config.block.defaults.margin)
-(set config.block.i3-workspace.padding-x config.block.defaults.padding-x)
-(set config.block.i3-workspace.radius config.block.defaults.radius)
-(set config.block.i3-workspace.label config.block.defaults.label)
-(set config.block.i3-workspace.font config.block.defaults.font)
-(set config.block.i3-workspace.font-size config.block.defaults.font-size)
-(set config.block.i3-workspace.love-font (love.graphics.newFont config.block.i3-workspace.font config.block.i3-workspace.font-size))
-(set config.block.i3-workspace.foreground-color config.theme.black)
-(set config.block.i3-workspace.background-color config.theme.green)
-(set config.block.i3-workspace.auto-fit config.block.defaults.auto-fit)
+(set config.block.i3-workspace (lib.default-settings config.theme))
 
 ; configuration for the free-disk-space block
-(set config.block.free-disk-space {})
-(set config.block.free-disk-space.width config.block.defaults.width)
-(set config.block.free-disk-space.height config.block.defaults.height)
-(set config.block.free-disk-space.margin config.block.defaults.margin)
-(set config.block.free-disk-space.padding-x config.block.defaults.padding-x)
-(set config.block.free-disk-space.radius config.block.defaults.radius)
+(set config.block.free-disk-space (lib.default-settings config.theme))
 (set config.block.free-disk-space.label " ")
-(set config.block.free-disk-space.font config.block.defaults.font)
-(set config.block.free-disk-space.font-size config.block.defaults.font-size)
-(set config.block.free-disk-space.love-font (love.graphics.newFont config.block.free-disk-space.font config.block.free-disk-space.font-size))
-(set config.block.free-disk-space.foreground-color config.theme.text)
-(set config.block.free-disk-space.background-color config.theme.black)
-(set config.block.free-disk-space.auto-fit config.block.defaults.auto-fit)
 
 ; configuration for the pacman block
-(set config.block.pacman {})
-(set config.block.pacman.width config.block.defaults.width)
-(set config.block.pacman.height config.block.defaults.height)
-(set config.block.pacman.margin config.block.defaults.margin)
-(set config.block.pacman.padding-x config.block.defaults.padding-x)
-(set config.block.pacman.radius config.block.defaults.radius)
+(set config.block.pacman (lib.default-settings config.theme))
 (set config.block.pacman.label "  ")
-(set config.block.pacman.font config.block.defaults.font)
-(set config.block.pacman.font-size config.block.defaults.font-size)
-(set config.block.pacman.love-font (love.graphics.newFont config.block.pacman.font config.block.pacman.font-size))
-(set config.block.pacman.foreground-color config.theme.text)
-(set config.block.pacman.background-color config.theme.black)
-(set config.block.pacman.auto-fit config.block.defaults.auto-fit)
 
 ; configuration for the i3-binding-state block
-(set config.block.i3-binding-state {})
-(set config.block.i3-binding-state.width config.block.defaults.width)
-(set config.block.i3-binding-state.height config.block.defaults.height)
-(set config.block.i3-binding-state.margin config.block.defaults.margin)
-(set config.block.i3-binding-state.padding-x config.block.defaults.padding-x)
-(set config.block.i3-binding-state.radius config.block.defaults.radius)
+(set config.block.i3-binding-state (lib.default-settings config.theme))
 (set config.block.i3-binding-state.label " ")
-(set config.block.i3-binding-state.font config.block.defaults.font)
-(set config.block.i3-binding-state.font-size config.block.defaults.font-size)
-(set config.block.i3-binding-state.love-font (love.graphics.newFont config.block.i3-binding-state.font config.block.i3-binding-state.font-size))
-(set config.block.i3-binding-state.foreground-color config.theme.black)
-(set config.block.i3-binding-state.background-color config.theme.purple)
-(set config.block.i3-binding-state.auto-fit config.block.defaults.auto-fit)
 
 ; configuration for the wmctrl block
-(set config.block.wmctrl {})
-(set config.block.wmctrl.width config.block.defaults.width)
-(set config.block.wmctrl.height config.block.defaults.height)
-(set config.block.wmctrl.margin (+ config.block.defaults.margin 1))
-(set config.block.wmctrl.padding-x config.block.defaults.padding-x)
+(set config.block.wmctrl (lib.default-settings config.theme))
+(set config.block.wmctrl.margin (+ config.block.wmctrl.margin 1))
 (set config.block.wmctrl.radius 4)
-(set config.block.wmctrl.label config.block.defaults.label)
-(set config.block.wmctrl.font config.block.defaults.font)
-(set config.block.wmctrl.font-size config.block.defaults.font-size)
-(set config.block.wmctrl.love-font (love.graphics.newFont config.block.wmctrl.font config.block.wmctrl.font-size))
-(set config.block.wmctrl.foreground-color config.theme.black)
-(set config.block.wmctrl.background-color config.theme.green)
-(set config.block.wmctrl.auto-fit config.block.defaults.auto-fit)
 
-(fn hostname []
-  (let [f (io.popen "/bin/hostname")
-        host (or (f:read "*a") "")
-        host (string.gsub host "\n$" "")]
-    (f:close)
-    host))
-
-(set config.all-blocks 
+(set config.blocks 
      {:left 
       [blocks.user
        blocks.separator
        blocks.wmctrl
-       ;;blocks.i3-workspace
-       ;;blocks.i3-binding-state
-       ;; blocks.separator
        blocks.window-title]
       :right 
       [blocks.time 
@@ -277,28 +103,6 @@
        blocks.separator
        blocks.memory
        blocks.separator
-       blocks.cpu
-       blocks.separator
-       {:load (partial (. blocks.free-disk-space :load) "/dev/nvme0n1p2" "ssd")
-        :draw (partial (. blocks.free-disk-space :draw) "/dev/nvme0n1p2" "ssd" "/ ")}
-       blocks.separator
-       (when (= (hostname) "thinker")
-         {:load (partial (. blocks.free-disk-space :load) "/home" "data")
-          :draw (partial (. blocks.free-disk-space :draw) "/home" "data" "/home ")})
-       (when (= (hostname) "archy")
-         {:load (partial (. blocks.free-disk-space :load) "/mnt/data" "data")
-          :draw (partial (. blocks.free-disk-space :draw) "/mnt/data" "data" "DATA ")})
-       ;;blocks.separator
-       ;;blocks.dunst
-       blocks.separator
-       blocks.pacman]})
-
-(set config.minimal-blocks 
-     {:left 
-      [blocks.user
-       blocks.window-title]
-      :right 
-      [blocks.time 
-       blocks.separator]})
+       blocks.cpu]})
 
 config

--- a/src/lib.fnl
+++ b/src/lib.fnl
@@ -1,0 +1,21 @@
+(local lib {})
+
+(set lib.default-settings 
+     (fn [theme]
+       (var block {})
+       (set block {})
+       (set block.margin 3)
+       (set block.padding-x 3)
+       (set block.width 140)
+       (set block.height 20)
+       (set block.auto-fit true)
+       (set block.label "")
+       (set block.font "JetBrainsMonoNerdFont-Regular.ttf")
+       (set block.font-size 14)
+       (set block.radius 6)
+       (set block.love-font (love.graphics.newFont block.font block.font-size))
+       (set block.background-color theme.black)
+       (set block.foreground-color theme.text)
+       block))
+
+lib

--- a/src/main.fnl
+++ b/src/main.fnl
@@ -3,7 +3,7 @@
 (local fennel (require "fennel"))
 
 (var bar {})
-(var minimal-mode false)
+(var config {})
 
 (fn love.run []
   (when love.load (love.load (love.arg.parseGameArguments arg) arg))
@@ -26,27 +26,21 @@
     (when love.timer (love.timer.sleep 0.001))))	
 
 (fn get-config []
-  (if minimal-mode
-    (let [conf (require "config.fnl")]
-      (set conf.blocks conf.minimal-blocks)
-      conf)
-    (let [user-config (love.filesystem.read "rc.fnl")
-          conf (if user-config
-                 (fennel.eval user-config)
-                 (require "config.fnl"))]
-      (set conf.blocks conf.all-blocks)
-      conf)))
+  (let [user-config (love.filesystem.read "rc.fnl")
+        conf (if user-config
+               (fennel.eval user-config)
+               (require "config.fnl"))]
+    conf))
 
 (fn love.load []
-  (let [config (get-config)]
-    (love.window.setDisplaySleepEnabled true) 
-    (love.graphics.setFont (love.graphics.newFont config.font config.font-size))
-    (set bar (window.place-window config.window))
-    (set bar (renderer.load-bar bar config))))
+  (set config (get-config))
+  (love.window.setDisplaySleepEnabled true) 
+  (love.graphics.setFont (love.graphics.newFont config.font config.font-size))
+  (set bar (window.place-window config.window))
+  (set bar (renderer.load-bar bar config)))
 
 (fn love.draw []
-  (let [config (get-config)
-        bg config.background-color
+  (let [bg config.background-color
         fg config.foreground-color
         channel (love.thread.getChannel "draw")]
     (love.graphics.clear bg)
@@ -66,12 +60,9 @@
   (print "Thread error!\n" errorstr)
   (print (thread:getError)))
 
-(fn set-minimal-mode []
-  (set minimal-mode (not minimal-mode)))
-
 (fn love.keypressed [_key]
   (case _key
-    "m" (set-minimal-mode) 
+    "r" (set config (get-config))
     "escape" (love.event.quit))
   (let [dr (love.thread.getChannel "draw")]
     (dr:push true)))


### PR DESCRIPTION
Simplify config to make it less verbose to make a custom configuration. 

This also includes a change to only load config on start-up, reloading config constantly is wasteful but also causes issues with breaking and config changes that are "automagically" applied based on the blocks state. e.g. changing a background to red on low battery. 

in the future some of this will need looking at again, at the moment, with the bar focused you can hit `r` to for a config reload, ideally after this we would force a redraw of every block, but this isn't currently happening. 